### PR TITLE
Remove synthetic accessor methods

### DIFF
--- a/metrics/src/main/java/com/facebook/battery/metrics/composite/CompositeMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/composite/CompositeMetricsCollector.java
@@ -35,7 +35,7 @@ public class CompositeMetricsCollector extends SystemMetricsCollector<CompositeM
       mMetricsCollectorMap = new SimpleArrayMap<>();
 
   public static class Builder {
-    private final SimpleArrayMap<Class<? extends SystemMetrics>, SystemMetricsCollector<?>>
+    final SimpleArrayMap<Class<? extends SystemMetrics>, SystemMetricsCollector<?>>
         mMetricsCollectorMap = new SimpleArrayMap<>();
 
     /**

--- a/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuFrequencyMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuFrequencyMetricsCollector.java
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.GuardedBy;
 public class CpuFrequencyMetricsCollector extends SystemMetricsCollector<CpuFrequencyMetrics> {
 
   private static final String CPU_DATA_PATH = "/sys/devices/system/cpu/";
-  private static int sCoresForTest = -1;
+  static int sCoresForTest = -1;
 
   @GuardedBy("this")
   @Nullable

--- a/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuMetricsCollector.java
@@ -114,7 +114,7 @@ public class CpuMetricsCollector extends SystemMetricsCollector<CpuMetrics> {
    * because Collectors can be called/created from any thread.
    */
   private static class Initializer {
-    private static final long CLOCK_TICKS_PER_SECOND =
+    static final long CLOCK_TICKS_PER_SECOND =
         Sysconf.getScClkTck(DEFAULT_CLOCK_TICKS_PER_SECOND);
   }
 }

--- a/metrics/src/main/java/com/facebook/battery/metrics/devicebattery/DeviceBatteryMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/devicebattery/DeviceBatteryMetricsCollector.java
@@ -34,16 +34,16 @@ public class DeviceBatteryMetricsCollector extends SystemMetricsCollector<Device
   private final Context mContext;
 
   @GuardedBy("this")
-  private long mBatteryRealtimeMs;
+  long mBatteryRealtimeMs;
 
   @GuardedBy("this")
-  private long mChargingRealtimeMs;
+  long mChargingRealtimeMs;
 
   @GuardedBy("this")
-  private long mLastUpdateMs;
+  long mLastUpdateMs;
 
   @GuardedBy("this")
-  private boolean mIsCurrentlyCharging;
+  boolean mIsCurrentlyCharging;
 
   public DeviceBatteryMetricsCollector(Context context) {
     mContext = context;
@@ -156,7 +156,7 @@ public class DeviceBatteryMetricsCollector extends SystemMetricsCollector<Device
    * @param intentType
    * @param now
    */
-  private void logIncorrectSequence(String intentType, long now) {
+  void logIncorrectSequence(String intentType, long now) {
     SystemMetricsLogger.wtf(
         TAG, "Consecutive " + intentType + "broadcasts: (" + mLastUpdateMs + ", " + now + ")");
   }

--- a/metrics/src/main/java/com/facebook/battery/metrics/network/TrafficStatsNetworkBytesCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/network/TrafficStatsNetworkBytesCollector.java
@@ -39,9 +39,9 @@ class TrafficStatsNetworkBytesCollector extends NetworkBytesCollector {
   private static final int UID = android.os.Process.myUid();
   private static final int TYPE_NONE = -1;
 
-  private final ConnectivityManager mConnectivityManager;
+  final ConnectivityManager mConnectivityManager;
   private final long[] mTotalBytes = new long[4];
-  private int mCurrentNetworkType;
+  int mCurrentNetworkType;
   private boolean mIsValid = true;
 
   @VisibleForTesting
@@ -83,7 +83,7 @@ class TrafficStatsNetworkBytesCollector extends NetworkBytesCollector {
     return true;
   }
 
-  private synchronized void updateTotalBytes() {
+  synchronized void updateTotalBytes() {
     long currentTotalTxBytes = TrafficStats.getUidTxBytes(UID);
     long currentTotalRxBytes = TrafficStats.getUidRxBytes(UID);
 


### PR DESCRIPTION
Closes #8 

Summary: Changed the visibility modifier of members from private to package private. This won't lead to synthetic accessor methods getting created for accessing the members (which were earlier private) inside the anonymous classes.