### PR TITLE
Fix failing tests in DeviceBatteryMetricsCollectorTest & AppWakeupMet…

### DIFF
--- a/metrics/src/test/java/com/facebook/battery/metrics/wakelock/WakeLockMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/wakelock/WakeLockMetricsCollectorTest.java
@@ -7,20 +7,20 @@
  */
 package com.facebook.battery.metrics.wakelock;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
-
 import android.content.Context;
 import android.os.PowerManager;
-import android.support.annotation.Nullable;
+
 import com.facebook.battery.metrics.core.ShadowSystemClock;
 import com.facebook.battery.metrics.core.SystemMetricsCollectorTest;
-import com.facebook.battery.metrics.core.SystemMetricsLogger;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(shadows = {ShadowSystemClock.class})
@@ -35,14 +35,6 @@ public class WakeLockMetricsCollectorTest
     mCollector = new WakeLockMetricsCollector();
     mPowerManager =
         (PowerManager) RuntimeEnvironment.application.getSystemService(Context.POWER_SERVICE);
-
-    SystemMetricsLogger.setDelegate(
-        new SystemMetricsLogger.Delegate() {
-          @Override
-          public void wtf(String tag, String message, @Nullable Throwable cause) {
-            throw new RuntimeException(tag + " " + message, cause);
-          }
-        });
   }
 
   @Test

--- a/metrics/src/test/java/com/facebook/battery/metrics/wakelock/WakeLockMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/wakelock/WakeLockMetricsCollectorTest.java
@@ -7,20 +7,22 @@
  */
 package com.facebook.battery.metrics.wakelock;
 
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
 import android.content.Context;
 import android.os.PowerManager;
-
+import android.support.annotation.Nullable;
 import com.facebook.battery.metrics.core.ShadowSystemClock;
 import com.facebook.battery.metrics.core.SystemMetricsCollectorTest;
+import com.facebook.battery.metrics.core.SystemMetricsLogger;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-
-import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(shadows = {ShadowSystemClock.class})
@@ -35,6 +37,14 @@ public class WakeLockMetricsCollectorTest
     mCollector = new WakeLockMetricsCollector();
     mPowerManager =
         (PowerManager) RuntimeEnvironment.application.getSystemService(Context.POWER_SERVICE);
+
+    SystemMetricsLogger.setDelegate(
+        new SystemMetricsLogger.Delegate() {
+          @Override
+          public void wtf(String tag, String message, @Nullable Throwable cause) {
+            throw new RuntimeException(tag + " " + message, cause);
+          }
+        });
   }
 
   @Test
@@ -137,6 +147,11 @@ public class WakeLockMetricsCollectorTest
     // Sanity check that nothing throws an exception or logs after disabling
     mCollector.release(wakeLockA, 0);
     mCollector.acquire(wakeLockA, 100);
+  }
+
+  @After
+  public void tearDown() {
+      SystemMetricsLogger.setDelegate(null);
   }
 
   @Override


### PR DESCRIPTION
Closes #11 

Summary: SystemMetricsLogger's delegate was being set to an anonymous class which was throwing a runtime exception, in the `WakeLockMetricsCollectorTest` class's setup method. Hence in the test suite, all the calls made to SystemMetricsLogger's wtf method were being rerouted to this delegate. This was leading to three tests failing in the `DeviceBatteryMetricsCollectorTest` & `AppWakeupMetricsCollectorTest` classes because of the aforementioned runtime exception. In order to fix this, I deleted the lines of code which were setting the delegate in the setup method of `WakeLockMetricsCollectorTest`.