### PR TITLE
Fix proc stat file reading for blanked comm column

### DIFF
--- a/metrics/src/main/java/com/facebook/battery/metrics/core/ProcFileReader.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/core/ProcFileReader.java
@@ -208,6 +208,10 @@ public class ProcFileReader {
     skipPast(' ');
   }
 
+  public void skipRightBrace() {
+    skipPast(')');
+  }
+
   public void skipLine() {
     skipPast('\n');
   }

--- a/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuMetricsCollector.java
+++ b/metrics/src/main/java/com/facebook/battery/metrics/cpu/CpuMetricsCollector.java
@@ -60,8 +60,10 @@ public class CpuMetricsCollector extends SystemMetricsCollector<CpuMetrics> {
         return false;
       }
 
+      reader.skipRightBrace();
+
       int index = 0;
-      while (index < PROC_USER_TIME_FIELD) {
+      while (index < PROC_USER_TIME_FIELD - 1) {
         reader.skipSpaces();
         index++;
       }

--- a/metrics/src/test/java/com/facebook/battery/metrics/cpu/CpuMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/cpu/CpuMetricsCollectorTest.java
@@ -100,6 +100,22 @@ public class CpuMetricsCollectorTest
   }
 
   @Test
+  public void testRealProcfileWithBlankedComm() throws Exception {
+    String stat =
+        "21031 (facebook.blank katana) S 354 354 0 0 -1 1077952832 227718 1446 318 0 9852 889 6 11 20 0 133 0 502496 2050461696 70553 4294967295 1 1 0 0 0 0 4608 0 1166120188 4294967295 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0";
+    TestableCpuMetricsCollector collector =
+        new TestableCpuMetricsCollector().setPath(createFile(stat));
+
+    CpuMetrics snapshot = new CpuMetrics();
+    assertThat(collector.getSnapshot(snapshot)).isTrue();
+
+    assertThat(snapshot.userTimeS).isEqualTo(9852.0 / 100);
+    assertThat(snapshot.systemTimeS).isEqualTo(889.0 / 100);
+    assertThat(snapshot.childUserTimeS).isEqualTo(6.0 / 100);
+    assertThat(snapshot.childSystemTimeS).isEqualTo(11.0 / 100);
+  }
+
+  @Test
   public void testSaneProcFile() throws Exception {
     StringBuilder testStringBuilder = new StringBuilder();
     for (int i = 0; i < 20; i++) {


### PR DESCRIPTION
We found wrong procStat file parsing when then comm part has a blank.