### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/metrics/src/test/java/com/facebook/battery/metrics/cpu/CpuMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/cpu/CpuMetricsCollectorTest.java
@@ -86,7 +86,9 @@ public class CpuMetricsCollectorTest
   @Test
   public void testRealProcfile() throws Exception {
     String stat =
-        "21031 (facebook.katana) S 354 354 0 0 -1 1077952832 227718 1446 318 0 9852 889 6 11 20 0 133 0 502496 2050461696 70553 4294967295 1 1 0 0 0 0 4608 0 1166120188 4294967295 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0";
+        "21031 (facebook.katana) S 354 354 0 0 -1 1077952832 227718 1446 318 0 9852 889 6 11 20 0"
+            + " 133 0 502496 2050461696 70553 4294967295 1 1 0 0 0 0 4608 0 1166120188 4294967295 0"
+            + " 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0";
     TestableCpuMetricsCollector collector =
         new TestableCpuMetricsCollector().setPath(createFile(stat));
 

--- a/metrics/src/test/java/com/facebook/battery/metrics/disk/DiskMetricsCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/disk/DiskMetricsCollectorTest.java
@@ -61,7 +61,8 @@ public class DiskMetricsCollectorTest
             + "cancelled_write_bytes: 10\n";
 
     String stat =
-        "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46";
+        "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33"
+            + " 34 35 36 37 38 39 40 41 42 43 44 45 46";
 
     DiskMetricsCollectorWithProcFile collector =
         new DiskMetricsCollectorWithProcFile().setPath(createFile(io), createFile(stat));
@@ -92,7 +93,8 @@ public class DiskMetricsCollectorTest
             + "cancelled_write_bytes: 10\n";
 
     String stat =
-        "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46";
+        "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33"
+            + " 34 35 36 37 38 39 40 41 42 43 44 45 46";
 
     DiskMetricsCollectorWithProcFile collector =
         new DiskMetricsCollectorWithProcFile().setPath(createFile(io), createFile(stat));
@@ -125,7 +127,8 @@ public class DiskMetricsCollectorTest
             + "cancelled_write_bytes: -1\n";
 
     String stat =
-        "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46";
+        "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33"
+            + " 34 35 36 37 38 39 40 41 42 43 44 45 46";
 
     DiskMetricsCollectorWithProcFile collector =
         new DiskMetricsCollectorWithProcFile().setPath(createFile(io), createFile(stat));

--- a/metrics/src/test/java/com/facebook/battery/metrics/network/QTagUidNetworkBytesCollectorTest.java
+++ b/metrics/src/test/java/com/facebook/battery/metrics/network/QTagUidNetworkBytesCollectorTest.java
@@ -32,7 +32,10 @@ import org.robolectric.shadows.ShadowProcess;
 public class QTagUidNetworkBytesCollectorTest {
 
   private static final String HEADERS =
-      "idx iface acct_tag_hex uid_tag_int cnt_set rx_bytes rx_packets tx_bytes tx_packets rx_tcp_bytes rx_tcp_packets rx_udp_bytes rx_udp_packets rx_other_bytes rx_other_packets tx_tcp_bytes tx_tcp_packets tx_udp_bytes tx_udp_packets tx_other_bytes tx_other_packets";
+      "idx iface acct_tag_hex uid_tag_int cnt_set rx_bytes rx_packets tx_bytes tx_packets"
+          + " rx_tcp_bytes rx_tcp_packets rx_udp_bytes rx_udp_packets rx_other_bytes"
+          + " rx_other_packets tx_tcp_bytes tx_tcp_packets tx_udp_bytes tx_udp_packets"
+          + " tx_other_bytes tx_other_packets";
   private static final String[] INDEXES = HEADERS.split(" ");
 
   TemporaryFolder mFolder = new TemporaryFolder();


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


